### PR TITLE
Added support for comments that work at the end of lines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,13 @@ Comments work by adding a semi-colon at the start of the line
 ; will    
 ; be      
 ; skipped 
+
 ```
-**Comments only work from the start of the line**
+
+Comments will also work at the end of a line
+```
+print($PLATFORM) ; this text will be ignored, and is merely a comment
+```
 
 There is also a list of helper functions
 

--- a/akbs/__main__.py
+++ b/akbs/__main__.py
@@ -212,9 +212,12 @@ if __name__ == '__main__':
         # Preprocess the file and evaluate variables and helper functions
         lines[i] = clrfuncs(clrvars(clrdefines(lines[i]))).strip()
         # Skip empty lines and comments
-        if not lines[i] or lines[i].startswith(";"):
+        if not lines[i] or lines[i].strip().startswith(";"):
             i += 1
             continue
+        # Otherwise, if the entire line is not a comment, only remove the part of it that is one.
+        if ';' in lines[i]:
+            lines[i] = lines[i].split(";")[0].strip()
         # Preprocesser define
         if lines[i].startswith("%define"):
             # Split by a space a maximum of 2 times


### PR DESCRIPTION
This pull request hardly changes anything. It just adds some rudimentary logic to ensure that comments work even at the end of a line. Like this:

```
print($PLATFORM) ; this extra text will be ignored
```

I have also updated the `README.md` file regarding the same.

(PS: Ignore the commit message, I was sleepy as hell. This is for comments at the end of lines, not middle.)